### PR TITLE
Fix migration documentation - Docker cp paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,16 +349,16 @@ docker-compose exec db rm /dmp
 
 4. Copy your data (nextcloud_app_1 is the name of your Nextcloud container):
 ```console
-docker cp ./data/ nextcloud_app_1:/var/www/html/data
+docker cp ./data/. nextcloud_app_1:/var/www/html/data
 docker-compose exec app chown -R www-data:www-data /var/www/html/data
-docker cp ./theming/ nextcloud_app_1:/var/www/html/theming
+docker cp ./theming/. nextcloud_app_1:/var/www/html/theming
 docker-compose exec app chown -R www-data:www-data /var/www/html/theming
 docker cp ./config/config.php nextcloud_app_1:/var/www/html/config
 docker-compose exec app chown -R www-data:www-data /var/www/html/config
 ```
 5. Copy only the custom apps you use (or simply redownload them from the web interface):
 ```console
-docker cp ./apps/ nextcloud_data:/var/www/html/custom_apps
+docker cp ./apps/. nextcloud_data:/var/www/html/custom_apps
 docker-compose exec app chown -R www-data:www-data /var/www/html/custom_apps
 ```
 


### PR DESCRIPTION
When you execute the commands as shown, Docker will copy the `data` directory to `/var/www/html/data/data` directory inside the container, instead of `/var/www/html/data`. This Docker behaviour is documented [here](https://docs.docker.com/engine/reference/commandline/cp/). 

By adding a `.` behind the paths, this behaviour is fixed, as per Docker's docs.